### PR TITLE
Modifications to use Babel (for older Node compatibility)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -37,5 +37,5 @@ jspm_packages
 .node_repl_history
 /.idea
 
-# Distribution Folder
-distribution
+# Source files
+index.js

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require("babel-polyfill");
+
 const _ = require('lodash');
 const Dynalite = require('dynalite');
 const chokidar = require('graceful-chokidar');

--- a/package.json
+++ b/package.json
@@ -2,10 +2,18 @@
   "name": "serverless-dynalite",
   "version": "1.0.2",
   "description": "Serverless plugin to run Dynalite locally to handle DynamoDB development. Can watch for table config changes.",
-  "main": "index.js",
+  "main": "distribution/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "babel index.js --out-dir distribution"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "stage-2"
+    ]
+  },
+  "prepublishOnly": "npm run build",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sdd/serverless-dynalite.git"
@@ -24,8 +32,14 @@
   "homepage": "https://github.com/sdd/serverless-dynalite#readme",
   "dependencies": {
     "aws-sdk": "^2.41.0",
+    "babel-polyfill": "^6.26.0",
     "dynalite": "^1.2.0",
     "graceful-chokidar": "^0.1.0",
     "lodash": "^4.17.4"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-stage-2": "^6.24.1"
   }
 }


### PR DESCRIPTION
Totally your prerogative to include these sorts of changes - but since I needed a version of this library for Node 6.X I wanted to at least offer my changes up-stream.

I've also (at least for now) created a package `serverless-dynalite-es5` that supports this, and which I am using. Can delete it if this gets merged in 👍 