### PR TITLE
Start watchHandler on `serverless offline start`

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "serverless-dynalite-example",
+  "version": "1.0.0",
+  "description": "",
+  "dependencies": {
+    "serverless-dynalite": "file:..",
+    "serverless-offline": "^3.16.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "example": "serverless offline start"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -1,0 +1,56 @@
+service: serverless-dynalite-example
+
+plugins:
+  - serverless-offline
+  - serverless-dynalite
+
+custom:
+  dynalite:
+    start:
+      port: 4567
+      region: us-east-1
+
+provider:
+  name: aws
+  runtime: nodejs6.10
+  stage: dev
+  
+# functions:
+#   rulesApi:
+#     handler: sample.handler
+#     events:
+#       - http:
+#           method: GET
+#           path: /
+#           cors: true
+
+resources:  
+  Resources:
+    ResultsTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: SampleTable
+        AttributeDefinitions:
+          - AttributeName: unique_key
+            AttributeType: S
+        KeySchema:
+          - AttributeName: unique_key
+            KeyType: HASH
+        ProvisionedThroughput:
+          ReadCapacityUnits: 5
+          WriteCapacityUnits: 5
+    DynamoDBIamPolicy:
+      Type: AWS::IAM::Policy
+      DependsOn: DynamoDbTable
+      Properties:
+        PolicyName: lambda-dynamodb
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:PutItem
+              Resource: arn:aws:dynamodb:*:*:table/SampleTable
+        Roles:
+          - Ref: IamRoleLambdaExecution

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ class ServerlessDynalite {
         this.hooks = {
             "dynalite:start:startHandler": this.startHandler.bind(this),
             "dynalite:watch:watchHandler": this.watchHandler.bind(this),
-            "before:offline:start": this.watchHandler.bind(this),
+            "before:offline:start:init": this.watchHandler.bind(this),
             "before:offline:start:end": this.endHandler.bind(this)
         };
     }


### PR DESCRIPTION
When running `serverless offline start`, I expected the serverless-dynalite plugin to start in watch mode, but it didn't appear to be starting. On troubleshooting, it looks like the hook to serverless-offline is not fully formed so serverless-dynalite isn't getting called when offline starts.

## To Duplicate:

Use the included example serverless file to reproduce.

In /example/package.json, swap the `serverless dynalite` dependency to use the npm version (1.2.0), then run `npm install` followed by `serverless offline start`. 

I only see this output, indicating dynalite wasn't run:
```text
Serverless: Starting Offline: undefined/us-east-1.

Serverless: Offline listening on http://localhost:3000
```

## Fix:

I looked at the hooks in serverless-offline and it has two lifecycle events: `init` and `end` ([here](https://github.com/dherault/serverless-offline/blob/97dc5eab4deb9af673a1b66f3f7a7367f82bf727/src/index.js#L50)). Switching that with a locally built package successfully starts the watch now:

- reset /example/package.json to use the file reference for server-less-dynalite
- `npm run build` in serverless-dynalite
- cd to /example, rm the package from node_modules, and `npm install`
- `serverless offline start`

And now I see the following:

```text
Serverless: Dynalite listening on http://localhost:4567
Serverless: Tables in config: ["SampleTable"]
Serverless: Current Tables: []
Serverless: Missing Tables: ["SampleTable"]
Serverless: Creating table SampleTable...
Serverless: Listening for table additions / deletions.
Serverless: Starting Offline: dev/us-east-1.

Serverless: Offline listening on http://localhost:3000
Serverless: Current Tables: ["SampleTable"]
```

Let me know if there is anything else I can provide that would be helpful or if I need to make any alterations to this PR for style purposes. Thanks!